### PR TITLE
重复厨师BUG修复（容易出现多个拉琪），厨师做做不了的菜导致的问题修复

### DIFF
--- a/src/Calculator.cpp
+++ b/src/Calculator.cpp
@@ -91,7 +91,7 @@ BanquetInfo getPrice(Chef *chef, Recipe *recipe, BanquetRule r, bool verbose) {
         if (verbose)
             std::cout << "Grade 0" << std::endl;
         {
-            BanquetInfo b = {0, 0};
+            BanquetInfo b = {0, 50};
             return b;
         }
     }

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -281,7 +281,10 @@ int e0::sumPrice(States s, CList *chefList, RList *recipeList, int log,
                 break;
             default:
                 int delta = std::abs(totalFull - bestFull[g]);
-                guestScore = (int)std::ceil(totalScore * (1 - 0.05 * delta));
+                if (delta < 20)
+                    guestScore = (int)std::ceil(totalScore * (1 - 0.05 * delta));
+                else
+                    guestScore = 0;
             }
             ans += guestScore;
             if (log & 0x1)
@@ -439,10 +442,10 @@ States perfectChef(States &s, CList *c) {
     States bestS = s;
     for (int i = 0; i < NUM_CHEFS; i++) {
         for (auto &chef : *c) {
-            newS.chef[i] = &chef;
             if (repeatChef(&chef, newS.chef, i)) {
                 continue;
             }
+            newS.chef[i] = &chef;
             States pS = perfectTool(newS);
             int pSs = e0::sumPrice(pS);
             int bestSs = e0::sumPrice(bestS);


### PR DESCRIPTION
function那里PerChef判重的逻辑应该是先判重再替换，而不是先替换再判重，会导致最后一个厨师（拉琪）即使重复还是保留了下来。

因为韩湘子饱食度太低了，会跑出不少结果做做不了的菜当0饱食度来算凑饱食，改成了做不了的菜加一个很离谱的饱食度，从而不能以这个方式凑饱食。